### PR TITLE
Enable multi-byte encoding for parameters

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -68,7 +68,7 @@ Client.prototype.call = function(options, callback, id){
         path: this.path,
         headers:{
             'content-type':(this.method=='POST') ? 'application/x-www-form-urlencoded' :'application/json',
-            'content-length':(requestData).length
+            'content-length':Buffer.byteLength(requestData)
         }
     };
     if(this.authNeeded){


### PR DESCRIPTION
Fixed bug occurring when sending multi-byte encoded strings in parameters.
Length was calculated incorrectly and server would stop receiving message before it's end.