### PR TITLE
Add option to force content-type

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -14,6 +14,7 @@ function Client(options){
     this.agent = (this.protocol==='https')? https : http;
     this.method = options.method || "POST";
     this.path = options.path || '/';
+    this.contentType = options.contentType || null;
     if(options && options.hasOwnProperty('user') && (options.hasOwnProperty('password') || options.hasOwnProperty('pass'))){
         this.authNeeded=true;
         this.authData = options.user;
@@ -67,7 +68,7 @@ Client.prototype.call = function(options, callback, id){
         port: this.port,
         path: this.path,
         headers:{
-            'content-type':(this.method=='POST') ? 'application/x-www-form-urlencoded' :'application/json',
+            'content-type':(this.contentType!==null) ? this.contentType : (this.method=='POST') ? 'application/x-www-form-urlencoded' :'application/json',
             'content-length':(requestData).length
         }
     };


### PR DESCRIPTION
geth requires RPC requests over HTTP to be sent with method POST and Content-Type: application/json. But this module wa sending POST requests with content-type application/x-www-form-urlencoded, causing geth to fail with a 415 status code.

This pull request allows the user to specify the content-type as an option, overriding the default behaviour.